### PR TITLE
Add sim-perception launch option to default.launch, change node name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Next, you can run a demo from `ada_demos`, that uses the plain Ada robot without
 ## Launching the robot for the feeding demo
 
 The feeding demo requires some more configuration and some additional nodes.
-It can be started by running `roslaunch ada_launch default.launch feeding:=true perception:=true`.
-To run it with simulated perception `roslaunch ada_launch default.launch feeding:=true`.
+It can be started by running `roslaunch ada_launch default.launch feeding:=true`.
+To run it with simulated perception `roslaunch ada_launch default.launch feeding:=true perception:=false`.
 
 You may also need to start
 - The camera node, running directly on the camera board. Typically the script is called something like `run_all.sh`

--- a/launch/default.launch
+++ b/launch/default.launch
@@ -1,7 +1,7 @@
 <launch>
 
   <arg name="feeding" default="false" doc="Boolean flag of whether to set up the robot for the feeding demo"/>
-  <arg name="perception" default="false" doc="Boolean flag of whether to set up the real perception for the feeding demo"/>
+  <arg name="perception" default="true" doc="Boolean flag of whether to set up the real perception for the feeding demo"/>
 
    <!-- the controller node itself -->
    <node pkg="jaco_hardware"


### PR DESCRIPTION
 For the feeding demo, this PR supports launching sim-perception. It also changes the node name to `food_detector`. I'd prefer this to match the name of the package for the sake of maintenance simplicity.

This PR has been tested by launching with perception true/false parameters and checking the marker topic being published.