### PR TITLE
Add trajectory constraints to ADA

### DIFF
--- a/config/controllers.yaml
+++ b/config/controllers.yaml
@@ -15,16 +15,22 @@ trajectory_controller:
     stopped_velocity_tolerance: 1.0
     j2n6s200_joint_1:
       goal: 0.02
+      trajectory: 0.05
     j2n6s200_joint_2:
       goal: 0.02
+      trajectory: 0.05
     j2n6s200_joint_3:
       goal: 0.02
+      trajectory: 0.05
     j2n6s200_joint_4:
       goal: 0.02
+      trajectory: 0.05
     j2n6s200_joint_5:
       goal: 0.02
+      trajectory: 0.05
     j2n6s200_joint_6:
       goal: 0.02
+      trajectory: 0.05
   gains: # Required because we're controlling a velocity interface
     j2n6s200_joint_1: {p: 3,  d: 0, i: 0, i_clamp: 1}
     j2n6s200_joint_2: {p: 3,  d: 0, i: 0, i_clamp: 1}
@@ -44,16 +50,22 @@ rewd_trajectory_controller:
     stopped_velocity_tolerance: 1.0
     j2n6s200_joint_1:
       goal: 0.02
+      trajectory: 0.05
     j2n6s200_joint_2:
       goal: 0.02
+      trajectory: 0.05
     j2n6s200_joint_3:
       goal: 0.02
+      trajectory: 0.05
     j2n6s200_joint_4:
       goal: 0.02
+      trajectory: 0.05
     j2n6s200_joint_5:
       goal: 0.02
+      trajectory: 0.05
     j2n6s200_joint_6:
       goal: 0.02
+      trajectory: 0.05
   gains: # Required because we're controlling a velocity interface
     j2n6s200_joint_1: {p: 3,  d: 0, i: 0, i_clamp: 1}
     j2n6s200_joint_2: {p: 3,  d: 0, i: 0, i_clamp: 1}
@@ -88,16 +100,22 @@ move_until_touch_topic_controller:
   constraints:
     j2n6s200_joint_1:
       goal: 0.02
+      trajectory: 0.05
     j2n6s200_joint_2:
       goal: 0.02
+      trajectory: 0.05
     j2n6s200_joint_3:
       goal: 0.02
+      trajectory: 0.05
     j2n6s200_joint_4:
       goal: 0.02
+      trajectory: 0.05
     j2n6s200_joint_5:
       goal: 0.02
+      trajectory: 0.05
     j2n6s200_joint_6:
       goal: 0.02
+      trajectory: 0.05
   gains: # Required because we're controlling a velocity interface
     j2n6s200_joint_1: {p: 3,  d: 0, i: 0, i_clamp: 1}
     j2n6s200_joint_2: {p: 3,  d: 0, i: 0, i_clamp: 1}


### PR DESCRIPTION
These are now enforced in `rewd_controllers`, see https://github.com/personalrobotics/rewd_controllers/pull/33

Just starting with the default from HERB, since these appear to work fine during manual testing on the feeding demo.